### PR TITLE
Без строки return error_code; перед меткой происходит постоянное попадание на метку "error:"

### DIFF
--- a/peripherals/Source/mik32_hal_spi.c
+++ b/peripherals/Source/mik32_hal_spi.c
@@ -425,6 +425,8 @@ HAL_StatusTypeDef HAL_SPI_Exchange(SPI_HandleTypeDef *hspi, uint8_t TransmitByte
             goto error;
         }
     }
+    
+    return error_code;
 
 error:
     __HAL_SPI_DISABLE(hspi);
@@ -544,6 +546,8 @@ HAL_StatusTypeDef HAL_SPI_ExchangeThreshold(SPI_HandleTypeDef *hspi, uint8_t Tra
             tx_counter = 0;
         }
     }
+
+    return error_code;
 
 error:
     __HAL_SPI_DISABLE(hspi);


### PR DESCRIPTION
Без строки return error_code; перед меткой происходит постоянное попадание на метку "error:". Я по-байтово передачу делал функцией HAL_SPI_Exchange и после каждого байта происходило отключение SPI на метке error (__HAL_SPI_DISABLE). После кратковременного отключения SPI - SCK подтягивается к питанию и при передаче следующего байта SPI снова включается, но между переданными байтами образуется один лишний тик - что сбивает всю передачу данных.