### PR TITLE
Инициализация Timer32 не должна конфигурировать лишние GPIO

### DIFF
--- a/peripherals/Source/mik32_hal_timer32.c
+++ b/peripherals/Source/mik32_hal_timer32.c
@@ -41,7 +41,7 @@ __attribute__((weak)) void HAL_TIMER32_Channel_MspInit(TIMER32_CHANNEL_HandleTyp
 
     if (timerChannel->TimerInstance == TIMER32_1)
     {
-        GPIO_InitStruct.Pin = GPIO_PIN_0 | GPIO_PIN_1 | GPIO_PIN_2 | GPIO_PIN_3;
+        GPIO_InitStruct.Pin = 1u << timerChannel->ChannelIndex;
         GPIO_InitStruct.Mode = HAL_GPIO_MODE_TIMER_SERIAL;
         GPIO_InitStruct.Pull = HAL_GPIO_PULL_NONE;
         HAL_GPIO_Init(GPIO_0, &GPIO_InitStruct);
@@ -50,7 +50,7 @@ __attribute__((weak)) void HAL_TIMER32_Channel_MspInit(TIMER32_CHANNEL_HandleTyp
 
     if (timerChannel->TimerInstance == TIMER32_2)
     {
-        GPIO_InitStruct.Pin = GPIO_PIN_0 | GPIO_PIN_1 | GPIO_PIN_2 | GPIO_PIN_3;
+        GPIO_InitStruct.Pin = 1u << timerChannel->ChannelIndex;
         GPIO_InitStruct.Mode = HAL_GPIO_MODE_TIMER_SERIAL;
         GPIO_InitStruct.Pull = HAL_GPIO_PULL_NONE;
         HAL_GPIO_Init(GPIO_1, &GPIO_InitStruct);


### PR DESCRIPTION
При использовании **не всех** 4-х ШИМ-каналов 32-х битного таймера нет необходимости конфигурировать **все** 4 ножки как используемые таймером.

Патч протестирован на примере вывода ШИМ-сигнала с 32-х битного таймера, в составе собственной прошивки.