### PR TITLE
QPI и XIP функции, нормализация условий запуска ШИМ 16-разрядного таймера

### DIFF
--- a/peripherals/Source/mik32_hal_timer16.c
+++ b/peripherals/Source/mik32_hal_timer16.c
@@ -608,11 +608,8 @@ void HAL_Timer16_StartPWM(Timer16_HandleTypeDef *htimer16, uint16_t Period, uint
     htimer16->Instance->CFGR &= ~TIMER16_CFGR_WAVE_M;
     HAL_Timer16_Enable(htimer16);
     
-    if(Period > Compare)
-    {
-        HAL_Timer16_SetCMP(htimer16, Compare);
-        HAL_Timer16_SetARR(htimer16, Period);
-    }
+    HAL_Timer16_SetCMP(htimer16, Compare);
+    HAL_Timer16_SetARR(htimer16, Period);
 
     __HAL_TIMER16_START_CONTINUOUS(htimer16);
 
@@ -743,8 +740,6 @@ void HAL_Timer16_Counter_Start_IT(Timer16_HandleTypeDef *htimer16, uint32_t Peri
  */
 void HAL_Timer16_StartPWM_IT(Timer16_HandleTypeDef *htimer16, uint16_t Period, uint16_t Compare)
 {
-
-
     HAL_Timer16_Disable(htimer16);
     htimer16->Instance->CFGR &= ~TIMER16_CFGR_WAVE_M;
     HAL_Timer16_Enable(htimer16);
@@ -752,13 +747,8 @@ void HAL_Timer16_StartPWM_IT(Timer16_HandleTypeDef *htimer16, uint16_t Period, u
     htimer16->Instance->ICR = TIMER16_ICR_ARROKCF_M | TIMER16_ICR_CMPOKCF_M | TIMER16_ICR_ARRMCF_M 
                             | TIMER16_ICR_CMPMCF_M | TIMER16_ICR_EXTTRIGCF_M;
     
-
-    
-    if(Period > Compare)
-    {
-        HAL_Timer16_SetCMP(htimer16, Compare);
-        HAL_Timer16_SetARR(htimer16, Period);
-    }
+    HAL_Timer16_SetCMP(htimer16, Compare);
+    HAL_Timer16_SetARR(htimer16, Period);
 
     htimer16->Instance->IER |= TIMER16_IER_ARROKIE_M | TIMER16_IER_CMPOKIE_M 
                             | TIMER16_IER_ARRMIE_M | TIMER16_IER_CMPMIE_M;
@@ -769,7 +759,6 @@ void HAL_Timer16_StartPWM_IT(Timer16_HandleTypeDef *htimer16, uint16_t Period, u
     }
 
     __HAL_TIMER16_START_CONTINUOUS(htimer16);
-
 }
 
 /**

--- a/utilities/Include/mik32_hal_spifi_w25.h
+++ b/utilities/Include/mik32_hal_spifi_w25.h
@@ -18,6 +18,8 @@ typedef struct __SPIFI_W25_ManufacturerDeviceIDTypeDef
 
 } W25_ManufacturerDeviceIDTypeDef;
 
+#define SPIFI_W25_XIP_NO_OPCODE 0x20
+
 #define SPIFI_W25_SREG1_BUSY_S 0
 #define SPIFI_W25_SREG1_BUSY_M (1 << SPIFI_W25_SREG1_BUSY_S)
 #define SPIFI_W25_SREG1_WRITE_ENABLE_S 1
@@ -52,6 +54,8 @@ typedef struct __SPIFI_W25_ManufacturerDeviceIDTypeDef
 
 void HAL_SPIFI_W25_WriteEnable(SPIFI_HandleTypeDef *spifi);
 
+void HAL_SPIFI_W25_WriteDisable(SPIFI_HandleTypeDef *spifi);
+
 uint8_t HAL_SPIFI_W25_ReadSREG(SPIFI_HandleTypeDef *spifi, HAL_SPIFI_W25_SREGTypeDef SREG);
 
 HAL_StatusTypeDef HAL_SPIFI_W25_WriteSREG(SPIFI_HandleTypeDef *spifi, uint8_t sreg1, uint8_t sreg2);
@@ -80,6 +84,8 @@ void HAL_SPIFI_W25_SectorErase4K(SPIFI_HandleTypeDef *spifi, uint32_t address);
 
 void HAL_SPIFI_W25_ReadData(SPIFI_HandleTypeDef *spifi, uint32_t address, uint16_t dataLength, uint8_t *dataBytes);
 
+void HAL_SPIFI_W25_ReadData_4addr(SPIFI_HandleTypeDef *spifi, uint32_t address, uint16_t dataLength, uint8_t *dataBytes);
+
 W25_ManufacturerDeviceIDTypeDef HAL_SPIFI_W25_ReadManufacturerDeviceID(SPIFI_HandleTypeDef *spifi);
 
 void HAL_SPIFI_W25_PageProgram_Quad(SPIFI_HandleTypeDef *spifi, uint32_t address, uint16_t dataLength, uint8_t *dataBytes);
@@ -88,8 +94,26 @@ void HAL_SPIFI_W25_ReadData_Quad(SPIFI_HandleTypeDef *spifi, uint32_t address, u
 
 void HAL_SPIFI_W25_ReadData_Quad_IO(SPIFI_HandleTypeDef *spifi, uint32_t address, uint16_t dataLength, uint8_t *dataBytes);
 
+void HAL_SPIFI_W25_ReadData_Quad_IO_XIP(SPIFI_HandleTypeDef *spifi, uint32_t address, uint16_t dataLength, uint8_t *dataBytes);
+
+void HAL_SPIFI_W25_ReadData_Quad_IO_XIP_Init(SPIFI_HandleTypeDef *spifi, uint32_t address, uint16_t dataLength, uint8_t *dataBytes);
+
+void HAL_SPIFI_W25_QPIEnable(SPIFI_HandleTypeDef *spifi);
+
+void HAL_SPIFI_W25_ReadData_Quad_IO_QPI(SPIFI_HandleTypeDef *spifi, uint32_t address, uint16_t dataLength, uint8_t *dataBytes);
+
+void HAL_SPIFI_W25_ReadData_Quad_IO_QPI_XIP(SPIFI_HandleTypeDef *spifi, uint32_t address, uint16_t dataLength, uint8_t *dataBytes);
+
+void HAL_SPIFI_W25_ReadData_Quad_IO_QPI_XIP_Init(SPIFI_HandleTypeDef *spifi, uint32_t address, uint16_t dataLength, uint8_t *dataBytes);
+
+void HAL_SPIFI_W25_QPIDisable(SPIFI_HandleTypeDef *spifi);
+
+void HAL_SPIFI_W25_Reset_QPI(SPIFI_HandleTypeDef *spifi);
+
+void HAL_SPIFI_W25_Reset(SPIFI_HandleTypeDef *spifi);
+
 HAL_StatusTypeDef HAL_SPIFI_W25_QuadEnable(SPIFI_HandleTypeDef *spifi);
 
 HAL_StatusTypeDef HAL_SPIFI_W25_QuadDisable(SPIFI_HandleTypeDef *spifi);
 
-#endif // MIK32_HAL_W25
+#endif // MIK32_HAL_SPIFI_W25

--- a/utilities/Source/mik32_hal_spifi_w25.c
+++ b/utilities/Source/mik32_hal_spifi_w25.c
@@ -21,6 +21,7 @@ typedef enum __HAL_SPIFI_W25_OPCodesTypeDef
     ERASE_PROGRAM_RESUME = 0x7A,
     POWER_DOWN = 0xB9,
     READ_DATA = 0x03,
+    READ_DATA_4ADDR = 0x13,
     FAST_READ = 0x0B,
     RELEASE_POWERDOWN_ID = 0xAB,
     MANUFACTURER_DEVICE_ID = 0x90,
@@ -42,9 +43,12 @@ typedef enum __HAL_SPIFI_W25_OPCodesTypeDef
     OCTAL_WORD_READ_QUAD_IO = 0xE3,
     SET_BURST_WITH_WRAP = 0x77,
     MANUFACTURER_DEVICE_ID_BY_QUAD_IO = 0x94,
-} HAL_SPIFI_W25_OPCodesTypeDef;
 
-#define HAL_SPIFI_W25_SREG2_BUSY 2
+    // QPI Instructions
+    SET_READ_PARAMETERS = 0xC0,
+    BURST_READ_WITH_WRAP = 0x0C,
+    DISABLE_QPI = 0xFF,
+} HAL_SPIFI_W25_OPCodesTypeDef;
 
 const uint32_t cmd_write_enable =
     SPIFI_DIRECTION_INPUT |
@@ -52,6 +56,13 @@ const uint32_t cmd_write_enable =
     SPIFI_CONFIG_CMD_FIELDFORM(SPIFI_FIELDFORM_ALL_SERIAL) |
     SPIFI_CONFIG_CMD_FRAMEFORM(SPIFI_FRAMEFORM_OPCODE) |
     SPIFI_CONFIG_CMD_OPCODE(WRITE_ENABLE);
+
+const uint32_t cmd_write_disable =
+    SPIFI_DIRECTION_INPUT |
+    SPIFI_CONFIG_CMD_INTLEN(0) |
+    SPIFI_CONFIG_CMD_FIELDFORM(SPIFI_FIELDFORM_ALL_SERIAL) |
+    SPIFI_CONFIG_CMD_FRAMEFORM(SPIFI_FRAMEFORM_OPCODE) |
+    SPIFI_CONFIG_CMD_OPCODE(WRITE_DISABLE);
 
 const uint32_t cmd_volatile_sr_write_enable =
     SPIFI_DIRECTION_INPUT |
@@ -102,6 +113,13 @@ const uint32_t cmd_read_data =
     SPIFI_CONFIG_CMD_FRAMEFORM(SPIFI_FRAMEFORM_OPCODE_3ADDR) |
     SPIFI_CONFIG_CMD_OPCODE(READ_DATA);
 
+const uint32_t cmd_read_data_4addr =
+    SPIFI_DIRECTION_INPUT |
+    SPIFI_CONFIG_CMD_INTLEN(0) |
+    SPIFI_CONFIG_CMD_FIELDFORM(SPIFI_FIELDFORM_ALL_SERIAL) |
+    SPIFI_CONFIG_CMD_FRAMEFORM(SPIFI_FRAMEFORM_OPCODE_4ADDR) |
+    SPIFI_CONFIG_CMD_OPCODE(READ_DATA_4ADDR);
+
 const uint32_t cmd_manufacturer_device_id =
     SPIFI_DIRECTION_INPUT |
     SPIFI_CONFIG_CMD_INTLEN(0) |
@@ -130,6 +148,13 @@ const uint32_t cmd_fast_read_quad_io =
     SPIFI_CONFIG_CMD_FRAMEFORM(SPIFI_FRAMEFORM_OPCODE_3ADDR) |
     SPIFI_CONFIG_CMD_OPCODE(FAST_READ_QUAD_IO);
 
+const uint32_t cmd_fast_read_quad_io_xip =
+    SPIFI_DIRECTION_INPUT |
+    SPIFI_CONFIG_CMD_INTLEN(3) |
+    SPIFI_CONFIG_CMD_FIELDFORM(SPIFI_FIELDFORM_ALL_PARALLEL) |
+    SPIFI_CONFIG_CMD_FRAMEFORM(SPIFI_FRAMEFORM_3ADDR) |
+    SPIFI_CONFIG_CMD_OPCODE(FAST_READ_QUAD_IO);
+
 const uint32_t cmd_read_sreg1_polling =
     SPIFI_DIRECTION_INPUT |
     SPIFI_CONFIG_CMD_POLL_INDEX(0) |
@@ -139,9 +164,70 @@ const uint32_t cmd_read_sreg1_polling =
     SPIFI_CONFIG_CMD_FRAMEFORM(SPIFI_FRAMEFORM_OPCODE) |
     SPIFI_CONFIG_CMD_OPCODE(READ_SREG1);
 
+const uint32_t cmd_qpi_enable =
+    SPIFI_DIRECTION_INPUT |
+    SPIFI_CONFIG_CMD_INTLEN(0) |
+    SPIFI_CONFIG_CMD_FIELDFORM(SPIFI_FIELDFORM_ALL_SERIAL) |
+    SPIFI_CONFIG_CMD_FRAMEFORM(SPIFI_FRAMEFORM_OPCODE) |
+    SPIFI_CONFIG_CMD_OPCODE(ENABLE_QPI);
+
+const uint32_t cmd_qpi_disable =
+    SPIFI_DIRECTION_INPUT |
+    SPIFI_CONFIG_CMD_INTLEN(0) |
+    SPIFI_CONFIG_CMD_FIELDFORM(SPIFI_FIELDFORM_ALL_PARALLEL) |
+    SPIFI_CONFIG_CMD_FRAMEFORM(SPIFI_FRAMEFORM_OPCODE) |
+    SPIFI_CONFIG_CMD_OPCODE(DISABLE_QPI);
+
+const uint32_t cmd_enable_reset_qpi =
+    SPIFI_DIRECTION_INPUT |
+    SPIFI_CONFIG_CMD_INTLEN(0) |
+    SPIFI_CONFIG_CMD_FIELDFORM(SPIFI_FIELDFORM_ALL_PARALLEL) |
+    SPIFI_CONFIG_CMD_FRAMEFORM(SPIFI_FRAMEFORM_OPCODE) |
+    SPIFI_CONFIG_CMD_OPCODE(ENABLE_RESET);
+
+const uint32_t cmd_reset_qpi =
+    SPIFI_DIRECTION_INPUT |
+    SPIFI_CONFIG_CMD_INTLEN(0) |
+    SPIFI_CONFIG_CMD_FIELDFORM(SPIFI_FIELDFORM_ALL_PARALLEL) |
+    SPIFI_CONFIG_CMD_FRAMEFORM(SPIFI_FRAMEFORM_OPCODE) |
+    SPIFI_CONFIG_CMD_OPCODE(RESET);
+
+const uint32_t cmd_enable_reset =
+    SPIFI_DIRECTION_INPUT |
+    SPIFI_CONFIG_CMD_INTLEN(0) |
+    SPIFI_CONFIG_CMD_FIELDFORM(SPIFI_FIELDFORM_ALL_SERIAL) |
+    SPIFI_CONFIG_CMD_FRAMEFORM(SPIFI_FRAMEFORM_OPCODE) |
+    SPIFI_CONFIG_CMD_OPCODE(ENABLE_RESET);
+
+const uint32_t cmd_reset =
+    SPIFI_DIRECTION_INPUT |
+    SPIFI_CONFIG_CMD_INTLEN(0) |
+    SPIFI_CONFIG_CMD_FIELDFORM(SPIFI_FIELDFORM_ALL_SERIAL) |
+    SPIFI_CONFIG_CMD_FRAMEFORM(SPIFI_FRAMEFORM_OPCODE) |
+    SPIFI_CONFIG_CMD_OPCODE(RESET);
+
+const uint32_t cmd_fast_read_quad_io_qpi =
+    SPIFI_DIRECTION_INPUT |
+    SPIFI_CONFIG_CMD_INTLEN(1) |
+    SPIFI_CONFIG_CMD_FIELDFORM(SPIFI_FIELDFORM_ALL_PARALLEL) |
+    SPIFI_CONFIG_CMD_FRAMEFORM(SPIFI_FRAMEFORM_OPCODE_3ADDR) |
+    SPIFI_CONFIG_CMD_OPCODE(FAST_READ_QUAD_IO);
+
+const uint32_t cmd_fast_read_quad_io_qpi_xip =
+    SPIFI_DIRECTION_INPUT |
+    SPIFI_CONFIG_CMD_INTLEN(1) |
+    SPIFI_CONFIG_CMD_FIELDFORM(SPIFI_FIELDFORM_ALL_PARALLEL) |
+    SPIFI_CONFIG_CMD_FRAMEFORM(SPIFI_FRAMEFORM_3ADDR) |
+    SPIFI_CONFIG_CMD_OPCODE(FAST_READ_QUAD_IO);
+
 void HAL_SPIFI_W25_WriteEnable(SPIFI_HandleTypeDef *spifi)
 {
     HAL_SPIFI_SendCommand_LL(spifi, cmd_write_enable, 0, 0, 0, 0, 0, HAL_SPIFI_TIMEOUT);
+}
+
+void HAL_SPIFI_W25_WriteDisable(SPIFI_HandleTypeDef *spifi)
+{
+    HAL_SPIFI_SendCommand_LL(spifi, cmd_write_disable, 0, 0, 0, 0, 0, HAL_SPIFI_TIMEOUT);
 }
 
 void HAL_SPIFI_W25_VolatileSRWriteEnable(SPIFI_HandleTypeDef *spifi)
@@ -211,6 +297,11 @@ void HAL_SPIFI_W25_ReadData(SPIFI_HandleTypeDef *spifi, uint32_t address, uint16
     HAL_SPIFI_SendCommand_LL(spifi, cmd_read_data, address, dataLength, dataBytes, 0, 0, HAL_SPIFI_TIMEOUT);
 }
 
+void HAL_SPIFI_W25_ReadData_4addr(SPIFI_HandleTypeDef *spifi, uint32_t address, uint16_t dataLength, uint8_t *dataBytes)
+{
+    HAL_SPIFI_SendCommand_LL(spifi, cmd_read_data_4addr, address, dataLength, dataBytes, 0, 0, HAL_SPIFI_TIMEOUT);
+}
+
 W25_ManufacturerDeviceIDTypeDef HAL_SPIFI_W25_ReadManufacturerDeviceID(SPIFI_HandleTypeDef *spifi)
 {
     uint8_t data[2] = {0};
@@ -240,18 +331,75 @@ void HAL_SPIFI_W25_ReadData_Quad_IO(SPIFI_HandleTypeDef *spifi, uint32_t address
     HAL_SPIFI_SendCommand_LL(spifi, cmd_fast_read_quad_io, address, dataLength, dataBytes, 0, 0, HAL_SPIFI_TIMEOUT);
 }
 
+void HAL_SPIFI_W25_ReadData_Quad_IO_XIP(SPIFI_HandleTypeDef *spifi, uint32_t address, uint16_t dataLength, uint8_t *dataBytes)
+{
+    HAL_SPIFI_SendCommand_LL(spifi, cmd_fast_read_quad_io_xip, address, dataLength, dataBytes, 0, SPIFI_W25_XIP_NO_OPCODE, HAL_SPIFI_TIMEOUT);
+}
+
+void HAL_SPIFI_W25_ReadData_Quad_IO_XIP_Init(SPIFI_HandleTypeDef *spifi, uint32_t address, uint16_t dataLength, uint8_t *dataBytes)
+{
+    HAL_SPIFI_SendCommand_LL(spifi, cmd_fast_read_quad_io, address, dataLength, dataBytes, 0, SPIFI_W25_XIP_NO_OPCODE, HAL_SPIFI_TIMEOUT);
+}
+
 HAL_StatusTypeDef HAL_SPIFI_W25_QuadEnable(SPIFI_HandleTypeDef *spifi)
 {
-    uint8_t sreg1 = HAL_SPIFI_W25_ReadSREG(spifi, W25_SREG1);
     uint8_t sreg2 = HAL_SPIFI_W25_ReadSREG(spifi, W25_SREG2);
-
-    return HAL_SPIFI_W25_WriteSREG(spifi, sreg1, sreg2 | HAL_SPIFI_W25_SREG2_BUSY);
+    if (sreg2 & SPIFI_W25_SREG2_QUAD_ENABLE_M) {
+        return HAL_OK;
+    } else {
+        uint8_t sreg1 = HAL_SPIFI_W25_ReadSREG(spifi, W25_SREG1);
+        return HAL_SPIFI_W25_WriteSREG(spifi, sreg1, sreg2 | SPIFI_W25_SREG2_QUAD_ENABLE_M);
+    }
 }
 
 HAL_StatusTypeDef HAL_SPIFI_W25_QuadDisable(SPIFI_HandleTypeDef *spifi)
 {
-    uint8_t sreg1 = HAL_SPIFI_W25_ReadSREG(spifi, W25_SREG1);
     uint8_t sreg2 = HAL_SPIFI_W25_ReadSREG(spifi, W25_SREG2);
+    if (sreg2 & SPIFI_W25_SREG2_QUAD_ENABLE_M) {
+        uint8_t sreg1 = HAL_SPIFI_W25_ReadSREG(spifi, W25_SREG1);
+        return HAL_SPIFI_W25_WriteSREG(spifi, sreg1, sreg2 & (~SPIFI_W25_SREG2_QUAD_ENABLE_M));    
+    } else {
+        return HAL_OK;
+    }
+}
 
-    return HAL_SPIFI_W25_WriteSREG(spifi, sreg1, sreg2 & (~HAL_SPIFI_W25_SREG2_BUSY));
+void HAL_SPIFI_W25_QPIEnable(SPIFI_HandleTypeDef *spifi)
+{
+    HAL_SPIFI_SendCommand_LL(spifi, cmd_qpi_enable, 0, 0, 0, 0, 0, HAL_SPIFI_TIMEOUT);
+}
+
+void HAL_SPIFI_W25_QPIDisable(SPIFI_HandleTypeDef *spifi)
+{
+    HAL_SPIFI_SendCommand_LL(spifi, cmd_qpi_disable, 0, 0, 0, 0, 0, HAL_SPIFI_TIMEOUT);
+}
+
+void HAL_SPIFI_W25_Reset_QPI(SPIFI_HandleTypeDef *spifi)
+{
+    HAL_SPIFI_SendCommand_LL(spifi, cmd_enable_reset_qpi, 0, 0, 0, 0, 0, HAL_SPIFI_TIMEOUT);
+    HAL_SPIFI_SendCommand_LL(spifi, cmd_reset_qpi, 0, 0, 0, 0, 0, HAL_SPIFI_TIMEOUT);
+    for (volatile int i = 0; i < 10000; i++) {
+    }
+}
+
+void HAL_SPIFI_W25_Reset(SPIFI_HandleTypeDef *spifi)
+{
+    HAL_SPIFI_SendCommand_LL(spifi, cmd_enable_reset, 0, 0, 0, 0, 0, HAL_SPIFI_TIMEOUT);
+    HAL_SPIFI_SendCommand_LL(spifi, cmd_reset, 0, 0, 0, 0, 0, HAL_SPIFI_TIMEOUT);
+    for (volatile int i = 0; i < 10000; i++) {
+    }
+}
+
+void HAL_SPIFI_W25_ReadData_Quad_IO_QPI(SPIFI_HandleTypeDef *spifi, uint32_t address, uint16_t dataLength, uint8_t *dataBytes)
+{
+    HAL_SPIFI_SendCommand_LL(spifi, cmd_fast_read_quad_io_qpi, address, dataLength, dataBytes, 0, 0, HAL_SPIFI_TIMEOUT);
+}
+
+void HAL_SPIFI_W25_ReadData_Quad_IO_QPI_XIP(SPIFI_HandleTypeDef *spifi, uint32_t address, uint16_t dataLength, uint8_t *dataBytes)
+{
+    HAL_SPIFI_SendCommand_LL(spifi, cmd_fast_read_quad_io_qpi_xip, address, dataLength, dataBytes, 0, SPIFI_W25_XIP_NO_OPCODE, HAL_SPIFI_TIMEOUT);
+}
+
+void HAL_SPIFI_W25_ReadData_Quad_IO_QPI_XIP_Init(SPIFI_HandleTypeDef *spifi, uint32_t address, uint16_t dataLength, uint8_t *dataBytes)
+{
+    HAL_SPIFI_SendCommand_LL(spifi, cmd_fast_read_quad_io_qpi, address, dataLength, dataBytes, 0, SPIFI_W25_XIP_NO_OPCODE, HAL_SPIFI_TIMEOUT);
 }


### PR DESCRIPTION
Простой пример наименьшего диапазона значений (0, 1, 2) регистра сравнения таймера для управления рабочим циклом ШИМ от 0 до 100 процентов, где генерируемая частота ШИМ равна половине тактовой частоты счётчика таймера:
```
  0% рабочего цикла при Period = 1 и Compare < 1 (0);
 50% рабочего цикла при Period = 1 и Compare = 1;
100% рабочего цикла при Period = 1 и Compare > 1 (2~65535).
```
Принцип работы ШИМ 16-ти и 32-разрядных таймеров MIK32 один и тот же.